### PR TITLE
[Build] Move pyproject dependency to requirements

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel
+          python -m pip install setuptools wheel
+          python -m pip install -r requirements.txt
 
       - name: Build wheels
         run: pip wheel --no-deps --wheel-dir wheelhouse .

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -15,6 +15,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          python -m pip install -r requirements.txt
           python -m pip install .
 
       - name: Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: |
-          python -m pip install .
+          python -m pip install -r requirements.txt
           python -m pip install -r tests/requirements.txt
+          python -m pip install .
           python -m pytest -v ./tests

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ working directory is set to a checkout of the
 ```bash
 python -m venv .venv
 . .venv/bin/activate
-python -m pip install .
+python -m pip install -r requirements.txt
 python -m pip install -r tests/requirements.txt
+python -m pip install .
 python -m pytest ./tests
 ```

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,17 @@
 Release Notes
 =============
 
+v1.0.0-alpha.X
+--------------
+
+### Improvements
+
+- Move `openassetio` dependency out of python project (`pyproject.toml`)
+  and instead have it as a `requirements.txt` dependency. OpenAssetIO
+  should be provided by the environment, and BAL enforcing this as part
+  of its install led to inflexibility.
+  [#31](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/31)
+
 v1.0.0-alpha.6
 --------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,6 @@
 name = "openassetio-manager-bal"
 version = "1.0.0a6"
 requires-python = ">=3.7"
-dependencies = [
-    "openassetio == 1.0.0a9"
-]
 
 authors = [
   { name = "Contributors to the OpenAssetIO project", email = "openassetio-discussion@lists.aswf.io" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+openassetio == 1.0.0a9


### PR DESCRIPTION
Having openassetio in the build dependencies for BAL was causing inflexibility, particularly in integrations CI as it was impossible to install it without also bringing in the PyPI OpenAssetIO. OpenAssetIO should more correctly be provided from the environment.