### PR TITLE
[Build] Reinstate Mediacreation Dependency

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,7 +33,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install setuptools wheel
-          python -m pip install -r requirements.txt
 
       - name: Build wheels
         run: pip wheel --no-deps --wheel-dir wheelhouse .

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -15,7 +15,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install -r requirements.txt
           python -m pip install -r tests/requirements.txt
           python -m pip install .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: |
-          python -m pip install -r requirements.txt
           python -m pip install -r tests/requirements.txt
           python -m pip install .
           python -m pytest -v ./tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 name = "openassetio-manager-bal"
 version = "1.0.0a13"
 requires-python = ">=3.7"
-dependencies = ["openassetio>=1.0.0b1.rev0"]
+dependencies = ["openassetio>=1.0.0b1.rev0", "openassetio-mediacreation>=1.0.0a7"]
 
 authors = [
   { name = "Contributors to the OpenAssetIO project", email = "openassetio-discussion@lists.aswf.io" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-openassetio-mediacreation>=1.0.0a7


### PR DESCRIPTION
#72

Now that https://github.com/OpenAssetIO/OpenAssetIO/issues/1088 is complete, we can depend properly on mediacreation, rather than leaving is an an optional install, since now it'll do the correct thing.